### PR TITLE
Patch up getRootText calls and fix single user blogpost

### DIFF
--- a/includes/SimpleBlogPage.php
+++ b/includes/SimpleBlogPage.php
@@ -30,7 +30,7 @@ class SimpleBlogPage extends Article {
 	 * Sets the 2 variables $AuthorName and $AuthorID.
 	 */
 	function getAuthor() {
-		$this->AuthorName = Title::newFromText( $this->getTitle()->getText() )->getRootText();
+		$this->AuthorName = Title::newFromText( $this->getTitle()->getRootTitle()->getText() )->getRootText();
 		$authorObj = User::newFromName( $this->AuthorName ); 
 		$this->AuthorID = $authorObj->getId();
 	}

--- a/includes/SimpleBlogPageHooks.php
+++ b/includes/SimpleBlogPageHooks.php
@@ -28,7 +28,7 @@ class SimpleBlogPageHooks {
 		$output = $context->getOutput();
 		$user = $context->getUser();
 
-		$basetitle = $editPage->getTitle()->getBaseText();
+		$basetitle = $editPage->getTitle()->getRootText();
 
 		$isnewpost = !$editPage->getTitle()->exists();
 		$isnotowner = !( $basetitle === $user->getName() );

--- a/includes/specials/lib/common.php
+++ b/includes/specials/lib/common.php
@@ -33,7 +33,7 @@ function getNewestPosts($includeall = true, $AuthorName = '') {
 		// only include blog posts by current user
 		$titleObj = Title::makeTitle( NS_USER_BLOG, $row->page_title );
 		// do not include User_blog:[username] pages as they are not blog posts
-		$authorOfPost = Title::newFromText( $titleObj->getText() )->getRootText();
+		$authorOfPost = Title::newFromText( $titleObj->getRootTitle()->getText() )->getRootText();
 
 		if ( ( $includeall || $authorOfPost === $AuthorName ) && strstr( $titleObj->getText(), '/' ) ) { 
 			$newestBlogPosts[] = [


### PR DESCRIPTION
This resolves a couple of odd cases where getRootText doesn't properly resolve for some reason (they need an intermediate call to getRootTitle) and fixes displaying a single users blog posts by properly getting the post author with getRootText.

The reason that second one happens is because getBaseText only removes the last `/` component ( [see class docs for title for more](https://doc.wikimedia.org/mediawiki-core/master/php/classTitle.html#aa3cd6cebca992f06ec1a8dbc1d55432c) ). getRootText meanwhile removes all components to get the actual name.

This should also close #27.