### PR TITLE
Cleanup and fix deprecated methods

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SimpleBlogPage",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"author": [
 		"Universal Omega",
 		"David Pean",
@@ -11,7 +11,7 @@
 	"url": "https://www.mediawiki.org/wiki/Extension:SimpleBlogPage",
 	"descriptionmsg": "simpleblogpage-desc",
 	"requires": {
-		"MediaWiki": ">= 1.35.0"
+		"MediaWiki": ">= 1.36.0"
 	},
 	"type": "other",
 	"callback": "SimpleBlogPageHooks::onRegistration",

--- a/includes/SimpleBlogPageHooks.php
+++ b/includes/SimpleBlogPageHooks.php
@@ -83,7 +83,7 @@ class SimpleBlogPageHooks {
 			}
 
 			// Add CSS
-			$out->addModuleStyles( 'ext.simpleBlogPage' );
+			$out->addModuleStyles( [ 'ext.simpleBlogPage' ] );
 
 			$article = new SimpleBlogPage( $title );
 		}

--- a/includes/specials/SpecialArticlesHome.php
+++ b/includes/specials/SpecialArticlesHome.php
@@ -28,7 +28,7 @@ class ArticlesHome extends SpecialPage {
 		$out = $this->getOutput();
 
 		// Add CSS
-		$out->addModuleStyles( 'ext.simpleBlogPage.articlesHome' );
+		$out->addModuleStyles( [ 'ext.simpleBlogPage.articlesHome' ] );
 
 		// Determine the page title and set it
 		$name = $this->msg( 'ah-all-posts' );


### PR DESCRIPTION
* Make `addModules()` and `addModuleStyles()` arrays: string values are deprecated
* Replace deprecated `WikiPage::factory()`
* Replace `WikiPage::doEditContent()`: removed in 1.39
* Cleanup tabbing

Fixes #35